### PR TITLE
Stop notifying Gitter about OVH

### DIFF
--- a/isthehubup.py
+++ b/isthehubup.py
@@ -290,7 +290,7 @@ async def main(once=False):
             "gh/binder-examples/requirements/master",
             [
                 Email("betatim@gmail.com"),
-                Gitter("jupyterhub/mybinder.org-deploy"),
+                #Gitter("jupyterhub/mybinder.org-deploy"),
             ],
             host="https://ovh.mybinder.org",
         ),


### PR DESCRIPTION
Currently we receive too many notifications this way so turn it off for the moment.