### PR TITLE
Remove Turing cluster from BinderBuilds check

### DIFF
--- a/isthehubup.py
+++ b/isthehubup.py
@@ -318,14 +318,14 @@ async def main(once=False):
             ],
             host="https://gesis.mybinder.org",
         ),
-        BinderBuilds(
-            "gh/binder-examples/requirements/master",
-            [
-                Email("betatim@gmail.com"),
-                Gitter("jupyterhub/mybinder.org-deploy"),
-            ],
-            host="https://turing.mybinder.org",
-        ),
+#         BinderBuilds(
+#             "gh/binder-examples/requirements/master",
+#             [
+#                 Email("betatim@gmail.com"),
+#                 Gitter("jupyterhub/mybinder.org-deploy"),
+#             ],
+#             host="https://turing.mybinder.org",
+#         ),
         # IsUp("https://httpbin.org/status/504", [Email("betatim@gmail.com")]),
     ]
 


### PR DESCRIPTION
Since the Turing is currently out of action, I'm removing it from the bot checks until it's up and running again.