### PR TITLE
Revert "Reinstate the bot checks to turing.mybinder.org"

### DIFF
--- a/isthehubup.py
+++ b/isthehubup.py
@@ -318,14 +318,14 @@ async def main(once=False):
             ],
             host="https://gesis.mybinder.org",
         ),
-        BinderBuilds(
-            "gh/binder-examples/requirements/master",
-            [
-                Email("betatim@gmail.com"),
-                Gitter("jupyterhub/mybinder.org-deploy"),
-            ],
-            host="https://turing.mybinder.org",
-        ),
+#         BinderBuilds(
+#             "gh/binder-examples/requirements/master",
+#             [
+#                 Email("betatim@gmail.com"),
+#                 Gitter("jupyterhub/mybinder.org-deploy"),
+#             ],
+#             host="https://turing.mybinder.org",
+#         ),
         # IsUp("https://httpbin.org/status/504", [Email("betatim@gmail.com")]),
     ]
 


### PR DESCRIPTION
Reverts betatim/isthehubup#14

The SSL certificates for turing are unhappy so disabling the hubup bot for the moment